### PR TITLE
Fix #25 - Add support for non-ASCII characters

### DIFF
--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/io/GTFSReadIn.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/io/GTFSReadIn.java
@@ -31,6 +31,8 @@ import edu.usf.cutr.go_sync.object.OperatorInfo;
 import edu.usf.cutr.go_sync.object.Route;
 import edu.usf.cutr.go_sync.object.Stop;
 import edu.usf.cutr.go_sync.tools.OsmFormatter;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 
 public class GTFSReadIn {
     private List<Stop> stops;
@@ -127,7 +129,7 @@ public class GTFSReadIn {
         String [] elements;
         int stopIdKey=-1, stopNameKey=-1, stopLatKey=-1, stopLonKey=-1;
         try {
-            BufferedReader br = new BufferedReader(new FileReader(fName));
+            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(fName),"UTF-8"));
             boolean isFirstLine = true;
             Hashtable keysIndex = new Hashtable();
             while ((thisLine = br.readLine()) != null) 
@@ -242,7 +244,7 @@ public class GTFSReadIn {
         String [] elements;
         int routeIdKey=-1, routeShortNameKey=-1;
         try {
-            BufferedReader br = new BufferedReader(new FileReader(routes_fName));
+            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(routes_fName),"UTF-8"));
             boolean isFirstLine = true;
             Hashtable keysIndex = new Hashtable();
             while ((thisLine = br.readLine()) != null) {
@@ -314,7 +316,7 @@ public class GTFSReadIn {
         // trips.txt read-in
         try {
             int tripIdKey=-1, routeIdKey=-1;
-            BufferedReader br = new BufferedReader(new FileReader(trips_fName));
+            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(trips_fName),"UTF-8"));
             boolean isFirstLine = true;
             while ((thisLine = br.readLine()) != null) {
                 if (isFirstLine) {
@@ -355,7 +357,7 @@ public class GTFSReadIn {
         // stop_times.txt read-in
         int stopIdKey=-1, tripIdKey = -1;
         try {
-            BufferedReader br = new BufferedReader(new FileReader(stop_times_fName));
+            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(stop_times_fName),"UTF-8"));
             boolean isFirstLine = true;
             while ((thisLine = br.readLine()) != null) {
                 if (isFirstLine) {

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/io/WriteFile.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/io/WriteFile.java
@@ -47,7 +47,7 @@ public class WriteFile {
         Writer output = null;
         File file = new File(fname);
         try {
-            output = new BufferedWriter(new FileWriter(file));
+            output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file),"UTF-8"));
             output.write(contents);
             output.close();
             System.out.println("Your file: "+fname+" has been written");
@@ -64,7 +64,7 @@ public class WriteFile {
         Writer output = null;
         File file = new File(fname);
         try {
-            output = new BufferedWriter(new FileWriter(file));
+            output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file),"UTF-8"));
             reportKeys.addAll(report.keySet());
             Iterator it = reportKeys.iterator();
             int count = 1;
@@ -223,7 +223,7 @@ public class WriteFile {
         Writer output = null;
         File file = new File(fname);
         try {
-            output = new BufferedWriter(new FileWriter(file));
+            output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file),"UTF-8"));
             //print key (first line)
             output.write(OperatorInfo.getGtfsFields());
             if(!isGtfsFormat) output.write(",OSM_TAGs");
@@ -299,7 +299,7 @@ public class WriteFile {
         Writer output = null;
         File file = new File(fname);
         try {
-            output = new BufferedWriter(new FileWriter(file));
+            output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file),"UTF-8"));
             output.write("stop_id,stop_name,stop_lat,stop_lon\n");
             for(int i=0; i<stops.size(); i++){
                 output.write(stops.get(i).getStopID()+","+stops.get(i).getStopName()+","+

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/osm/HttpRequest.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/osm/HttpRequest.java
@@ -547,7 +547,7 @@ public class HttpRequest {
                 BufferedReader response;
                 String s;
                 if(responseCode==HttpURLConnection.HTTP_OK) {
-                    response = new BufferedReader(new InputStreamReader (conn.getInputStream()));
+                    response = new BufferedReader(new InputStreamReader (conn.getInputStream(),"UTF-8"));
                     char[] cbuf = new char[]{};
                     response.read(cbuf);
                     s = response.readLine();


### PR DESCRIPTION
Fix for #25
- When obtaining data from OSM non-ASCII characters might be mishandled
- When reading data from GTFS files non-ASCII characters might be
mishandled
- When writing output non-ASCII characters might be mishandled