### PR TITLE
Fix #36 - The following web site shows that the XAPI locations used in gtfs-osm…

### DIFF
--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/osm/HttpRequest.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/osm/HttpRequest.java
@@ -189,7 +189,7 @@ public class HttpRequest {
 //        String urlSuffix = "/api/0.6/relation[route=bus][bbox="+left+","+bottom+","+right+","+top+"]";
 //        String[] hosts = {"http://open.mapquestapi.com/xapi","http://www.informationfreeway.org"};
     	String urlSuffix = "?relation[route=bus][bbox="+left+","+bottom+","+right+","+top+"]";
-        String[] hosts = {"http://api.openstreetmap.fr/xapi","http://www.informationfreeway.org"};    	        
+        String[] hosts = {"http://www.overpass-api.de/api/xapi_meta","http://overpass.openstreetmap.ru/cgi/xapi_meta"};
         try {
             // get data from server
             String s = sendRequest(hosts, urlSuffix, "GET", "");


### PR DESCRIPTION
…-sync are no longer active, there are 2 new active locations instead.

    https://wiki.openstreetmap.org/wiki/Xapi#Web_services_available

However, this page suggests that XAPI is no longer the recommended API, and that new projects should use Overpass QL. For now, stay with XAPI and consider other changes in the future.

Here's a quote from the above web site.

XAPI is no longer recommended as none of the original native installations are available anymore.
Legacy XAPI applications can still leverage the XAPI Compatibility Layer, new projects should use Overpass QL instead.

close: #36