### PR TITLE
donotUploadAllButtonActionPerformed should check for null

### DIFF
--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/gui/ReportViewer.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/gui/ReportViewer.java
@@ -2311,6 +2311,9 @@ public class ReportViewer extends javax.swing.JFrame implements TableModelListen
     	
 //    	GtfsArrayList.remove(o)
     	Stop s = (Stop)gtfsStopsComboBox.getSelectedItem();
+        if (s == null) {
+            return;
+        }
     	String category = s.getReportCategory();
   //  	ArrayList<Stop> GtfsAllArrayList = new ArrayList<Stop>() ;
     	LinkedList<Stop> GtfsAllLinkedList = new LinkedList<Stop>(Arrays.asList(gtfsAll));  


### PR DESCRIPTION
in return from gtfsStopsComboBox.getSelectedItem() before
dereferencing return.

I had an error while running application which this message:

Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at edu.usf.cutr.go_sync.gui.ReportViewer.donotUploadAllButtonActionPerformed(ReportViewer.java:2314)
	at edu.usf.cutr.go_sync.gui.ReportViewer.access$1200(ReportViewer.java:85)